### PR TITLE
Adjust package.json to fix type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "module": "dist/index.mjs",
   "exports": {
     "import": "./dist/index.mjs",
-    "require": "./dist/index.js"
+    "require": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
When using the exports field in package.json the types field will be ignored. Have a look here for more information: https://stackoverflow.com/a/76212193