### PR TITLE
Fix importing `openweather-api-node` in Bun

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "dist/index.mjs",
   "exports": {
     "types": "./dist/index.d.ts",
+    "bun": "./dist/index.js",
     "import": "./dist/index.mjs",
     "require": "./dist/index.js"
   },


### PR DESCRIPTION
This allows either of the following to work as expected in Bun:

```js
import {OpenWeatherAPI} from 'openweather-api-node';
const {OpenWeatherAPI} = require(`openweather-api-node`);
```

This avoids the generated ESM -> CJS wrapper when imported in Bun.

Fixes #9 