### PR TITLE
fix lang option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ export class OpenWeatherAPI {
             break;
 
           case "language":
+          case "lang":
             this.setLanguage(value);
             break;
 
@@ -688,7 +689,8 @@ export class OpenWeatherAPI {
             break;
           }
 
-          case "language": {
+          case "language":
+          case "lang": {
             parsedOptions.lang = this.evaluateLanguage(value);
             break;
           }


### PR DESCRIPTION
Hi @loloToster 😃 
According to:
https://github.com/loloToster/openweather-api-node/blob/192a560b6077b352d2c20c6f7eb5c5f82afca778/src/types/options.ts#L12-L14
property of "options" should be "lang" and not "language".
But, to avoid breaking this for anyone already using "language", I suggest simply adding "lang" in the switches