### PR TITLE
Add min and max temperature to current and forecasted weather

### DIFF
--- a/src/parsers/onecall/current-parser.ts
+++ b/src/parsers/onecall/current-parser.ts
@@ -19,6 +19,8 @@ function currentParser(data: any): CurrentWeather {
     weather: {
       temp: { cur: data.current.temp },
       feelsLike: { cur: data.current.feels_like },
+      tempMin: NaN,
+      tempMax: NaN,
       pressure: data.current.pressure,
       humidity: data.current.humidity,
       dewPoint: data.current.dew_point,

--- a/src/parsers/weather/current-parser.ts
+++ b/src/parsers/weather/current-parser.ts
@@ -19,6 +19,8 @@ function currentParser(data: any): CurrentWeather {
     weather: {
       temp: { cur: data.main.temp },
       feelsLike: { cur: data.main.feels_like },
+      tempMin: data.main.temp_min,
+      tempMax: data.main.temp_max,
       pressure: data.main.pressure,
       humidity: data.main.humidity,
       dewPoint: data.dew_point, 

--- a/src/parsers/weather/forecast-parser.ts
+++ b/src/parsers/weather/forecast-parser.ts
@@ -25,6 +25,8 @@ function forecastParser(data: any, limit: number): ForecastWeather[] {
       weather: {
         temp: { cur: element.main.temp },
         feelsLike: { cur: element.main.feels_like },
+        tempMin: element.main.temp_min,
+        tempMax: element.main.temp_max,
         pressure: element.main.pressure,
         humidity: element.main.humidity,
         clouds: element.clouds.all,

--- a/src/types/weather/current.ts
+++ b/src/types/weather/current.ts
@@ -17,6 +17,18 @@ export interface CurrentConditions {
    */
   feelsLike: CurrentTemperatures;
   /**
+   * Current minimum temperature
+   * 
+   * Units – default: kelvin, metric: Celsius, imperial: Fahrenheit.
+   */
+  tempMin: number;
+  /**
+   * Current maximum temperature
+   * 
+   * Units – default: kelvin, metric: Celsius, imperial: Fahrenheit.
+   */
+  tempMax: number;
+  /**
    * Atmospheric pressure on the sea level, hPa
    */
   pressure: number;

--- a/src/types/weather/forecast.ts
+++ b/src/types/weather/forecast.ts
@@ -17,6 +17,18 @@ export interface ForecastConditions {
    */
   feelsLike: ForecastTemperatures;
   /**
+   * Minimum temperature
+   * 
+   * Units – default: kelvin, metric: Celsius, imperial: Fahrenheit.
+   */
+  tempMin: number;
+  /**
+   * Maximum temperature
+   * 
+   * Units – default: kelvin, metric: Celsius, imperial: Fahrenheit.
+   */
+  tempMax: number;
+  /**
    * Atmospheric pressure on the sea level, hPa
    */
   pressure: number;


### PR DESCRIPTION
I noticed that the [`/data/2.5/weather`](https://openweathermap.org/current#fields_json) and [`/data/2.5/forecast`](https://openweathermap.org/forecast5#fields_JSON) endpoints return the properties `temp_min` and `temp_max`, but your API wrapper ignores them.

I don't really understand the reason behind the [`CurrentTemperatures`](https://github.com/loloToster/openweather-api-node/blob/67077261590bb63524f8d50be6bf78259541de74/src/types/weather/current.ts#L3-L8) interface and directly use a type of number for the new properties: https://github.com/nkilders/openweather-api-node/blob/6096c8ea62ed200f4e790a1188a923e09ba76a3f/src/types/weather/current.ts#L19-L30.

Unfortunately, you use the same `CurrentWeather` interface in the ["normal" currentParser](https://github.com/loloToster/openweather-api-node/blob/67077261590bb63524f8d50be6bf78259541de74/src/parsers/weather/current-parser.ts#L1-L3) and the [one call currentParser](https://github.com/loloToster/openweather-api-node/blob/67077261590bb63524f8d50be6bf78259541de74/src/parsers/onecall/current-parser.ts#L1-L3), but the [one call endpoint](https://openweathermap.org/api/one-call-3#parameter) doesn't provide these properties. Consequently, I set their values to `NaN`.